### PR TITLE
fix: register concrete keys

### DIFF
--- a/crypto/codec/amino.go
+++ b/crypto/codec/amino.go
@@ -2,11 +2,19 @@ package codec
 
 import (
 	"github.com/cosmos/evm/crypto/ethsecp256k1"
+	legacysecp256k1 "github.com/cosmos/evm/legacy/ethsecp256k1"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+)
+
+const (
+	// PrivKeyName defines the amino encoding name for the EthSecp256k1 private key
+	LegacyPrivKeyName = "ethermint/PrivKeyEthSecp256k1"
+	// PubKeyName defines the amino encoding name for the EthSecp256k1 public key
+	LegacyPubKeyName = "ethermint/PubKeyEthSecp256k1"
 )
 
 // RegisterCrypto registers all crypto dependency types with the provided Amino
@@ -16,6 +24,11 @@ func RegisterCrypto(cdc *codec.LegacyAmino) {
 		ethsecp256k1.PubKeyName, nil)
 	cdc.RegisterConcrete(&ethsecp256k1.PrivKey{},
 		ethsecp256k1.PrivKeyName, nil)
+
+	cdc.RegisterConcrete(&legacysecp256k1.PubKey{},
+		LegacyPubKeyName, nil)
+	cdc.RegisterConcrete(&legacysecp256k1.PrivKey{},
+		LegacyPrivKeyName, nil)
 
 	keyring.RegisterLegacyAminoCodec(cdc)
 	cryptocodec.RegisterCrypto(cdc)


### PR DESCRIPTION
# Description

Register ethermint keys to enable signing transactions with accounts which already have existing ethermint pubkey types

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
