### PR TITLE
fix: missing legacy MsgEthereumTx funcs

### DIFF
--- a/legacy/evm/codec.go
+++ b/legacy/evm/codec.go
@@ -1,0 +1,40 @@
+package evm
+
+import (
+	errorsmod "cosmossdk.io/errors"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
+	proto "github.com/cosmos/gogoproto/proto"
+)
+
+// PackTxData constructs a new Any packed with the given tx data value. It returns
+// an error if the client state can't be casted to a protobuf message or if the concrete
+// implementation is not registered to the protobuf codec.
+func PackTxData(txData TxData) (*codectypes.Any, error) {
+	msg, ok := txData.(proto.Message)
+	if !ok {
+		return nil, errorsmod.Wrapf(errortypes.ErrPackAny, "cannot proto marshal %T", txData)
+	}
+
+	anyTxData, err := codectypes.NewAnyWithValue(msg)
+	if err != nil {
+		return nil, errorsmod.Wrap(errortypes.ErrPackAny, err.Error())
+	}
+
+	return anyTxData, nil
+}
+
+// UnpackTxData unpacks an Any into a TxData. It returns an error if the
+// client state can't be unpacked into a TxData.
+func UnpackTxData(cdcAny *codectypes.Any) (TxData, error) {
+	if cdcAny == nil {
+		return nil, errorsmod.Wrap(errortypes.ErrUnpackAny, "protobuf Any message cannot be nil")
+	}
+
+	txData, ok := cdcAny.GetCachedValue().(TxData)
+	if !ok {
+		return nil, errorsmod.Wrapf(errortypes.ErrUnpackAny, "cannot unpack Any into TxData %T", cdcAny)
+	}
+
+	return txData, nil
+}

--- a/legacy/evm/msg_ethereum_tx.go
+++ b/legacy/evm/msg_ethereum_tx.go
@@ -1,0 +1,267 @@
+package evm
+
+// Copyright 2021 Evmos Foundation
+// This file is part of Evmos' Ethermint library.
+//
+// The Ethermint library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Ethermint library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Ethermint library. If not, see https://github.com/zeta-chain/ethermint/blob/main/LICENSE
+
+import (
+	"errors"
+	"math/big"
+
+	sdkmath "cosmossdk.io/math"
+	"google.golang.org/protobuf/proto"
+
+	errorsmod "cosmossdk.io/errors"
+	"github.com/cosmos/cosmos-sdk/client"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+)
+
+var (
+	_ sdk.Msg    = &MsgEthereumTx{}
+	_ sdk.Tx     = &MsgEthereumTx{}
+	_ ante.GasTx = &MsgEthereumTx{}
+	_ sdk.Msg    = &MsgUpdateParams{}
+
+	_ codectypes.UnpackInterfacesMessage = MsgEthereumTx{}
+)
+
+// message type and route constants
+const (
+	// TypeMsgEthereumTx defines the type string of an Ethereum transaction
+	TypeMsgEthereumTx = "ethereum_tx"
+)
+
+// recoverSender recovers the sender address from the transaction signature.
+func (msg *MsgEthereumTx) recoverSender(chainID *big.Int) (common.Address, error) {
+	return ethtypes.LatestSignerForChainID(chainID).Sender(msg.AsTransaction())
+}
+
+// Route returns the route value of an MsgEthereumTx.
+func (msg MsgEthereumTx) Route() string { return "evm" }
+
+// Type returns the type value of an MsgEthereumTx.
+func (msg MsgEthereumTx) Type() string { return TypeMsgEthereumTx }
+
+// ValidateBasic implements the sdk.Msg interface. It performs basic validation
+// checks of a Transaction. If returns an error if validation fails.
+func (msg MsgEthereumTx) ValidateBasic() error {
+	// Validate Size_ field, should be kept empty
+	if msg.Size_ != 0 {
+		return errorsmod.Wrapf(errortypes.ErrInvalidRequest, "tx size is deprecated")
+	}
+
+	if len(msg.From) == 0 {
+		return errorsmod.Wrapf(errortypes.ErrInvalidRequest, "sender address is missing")
+	}
+
+	txData, err := UnpackTxData(msg.Data)
+	if err != nil {
+		return errorsmod.Wrap(err, "failed to unpack tx data")
+	}
+
+	// prevent txs with 0 gas to fill up the mempool
+	if txData.GetGas() == 0 {
+		return errorsmod.Wrap(errors.New("invalid gas limit"), "gas limit must not be zero")
+	}
+
+	if err := txData.Validate(); err != nil {
+		return err
+	}
+
+	// Validate Hash field after validated txData to avoid panic
+	txHash := msg.AsTransaction().Hash().Hex()
+	if msg.Hash != txHash {
+		return errorsmod.Wrapf(errortypes.ErrInvalidRequest, "invalid tx hash %s, expected: %s", msg.Hash, txHash)
+	}
+
+	return nil
+}
+
+// GetMsgs returns a single MsgEthereumTx as an sdk.Msg.
+func (msg *MsgEthereumTx) GetMsgs() []sdk.Msg {
+	return []sdk.Msg{msg}
+}
+
+func (msg *MsgEthereumTx) GetMsgsV2() ([]proto.Message, error) {
+	return nil, errors.New("not implemented")
+}
+
+// GetSender convert the From field to common.Address
+// From should always be set, which is validated in ValidateBasic
+func (msg *MsgEthereumTx) GetSender(chainID *big.Int) (common.Address, error) {
+	if msg.From != "" {
+		return common.HexToAddress(msg.From), nil
+	}
+	signer := ethtypes.LatestSignerForChainID(chainID)
+	from, err := signer.Sender(msg.AsTransaction())
+	if err != nil {
+		return common.Address{}, err
+	}
+
+	msg.From = from.Hex()
+	return from, nil
+}
+
+// GetSignBytes returns the Amino bytes of an Ethereum transaction message used
+// for signing.
+//
+// NOTE: This method cannot be used as a chain ID is needed to create valid bytes
+// to sign over. Use 'RLPSignBytes' instead.
+func (msg MsgEthereumTx) GetSignBytes() []byte {
+	panic("must use 'RLPSignBytes' with a chain ID to get the valid bytes to sign")
+}
+
+// GetGas implements the GasTx interface. It returns the GasLimit of the transaction.
+func (msg MsgEthereumTx) GetGas() uint64 {
+	txData, err := UnpackTxData(msg.Data)
+	if err != nil {
+		return 0
+	}
+	return txData.GetGas()
+}
+
+// GetFee returns the fee for non dynamic fee tx
+func (msg MsgEthereumTx) GetFee() *big.Int {
+	txData, err := UnpackTxData(msg.Data)
+	if err != nil {
+		return nil
+	}
+	return txData.Fee()
+}
+
+// GetEffectiveFee returns the fee for dynamic fee tx
+func (msg MsgEthereumTx) GetEffectiveFee(baseFee *big.Int) *big.Int {
+	txData, err := UnpackTxData(msg.Data)
+	if err != nil {
+		return nil
+	}
+	return txData.EffectiveFee(baseFee)
+}
+
+// GetFrom loads the ethereum sender address from the sigcache and returns an
+// sdk.AccAddress from its bytes
+func (msg *MsgEthereumTx) GetFrom() sdk.AccAddress {
+	if msg.From == "" {
+		return nil
+	}
+
+	return common.HexToAddress(msg.From).Bytes()
+}
+
+// AsTransaction creates an Ethereum Transaction type from the msg fields
+func (msg MsgEthereumTx) AsTransaction() *ethtypes.Transaction {
+	txData, err := UnpackTxData(msg.Data)
+	if err != nil {
+		return nil
+	}
+
+	return ethtypes.NewTx(txData.AsEthereumData())
+}
+
+func bigMin(x, y *big.Int) *big.Int {
+	if x.Cmp(y) > 0 {
+		return y
+	}
+	return x
+}
+
+// AsMessage creates an Ethereum core.Message from the msg fields
+func (msg MsgEthereumTx) AsMessage(signer ethtypes.Signer, baseFee *big.Int) (*core.Message, error) {
+	txData, err := UnpackTxData(msg.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	gasPrice, gasFeeCap, gasTipCap := txData.GetGasPrice(), txData.GetGasFeeCap(), txData.GetGasTipCap()
+	if baseFee != nil {
+		gasPrice = bigMin(gasPrice.Add(gasTipCap, baseFee), gasFeeCap)
+	}
+	var from common.Address
+	if len(msg.From) > 0 {
+		// user can't set arbitrary value in `From` field in transaction,
+		// the SigVerify ante handler will verify the signature and recover
+		// the sender address and populate the `From` field, so the other code can
+		// use it directly when available.
+		from = common.HexToAddress(msg.From)
+	} else {
+		// heavy path
+		from, err = signer.Sender(msg.AsTransaction())
+		if err != nil {
+			return nil, err
+		}
+	}
+	ethMsg := &core.Message{
+		From:       from,
+		To:         txData.GetTo(),
+		Nonce:      txData.GetNonce(),
+		Value:      txData.GetValue(),
+		GasLimit:   txData.GetGas(),
+		GasPrice:   gasPrice,
+		GasFeeCap:  gasFeeCap,
+		GasTipCap:  gasTipCap,
+		Data:       txData.GetData(),
+		AccessList: txData.GetAccessList(),
+	}
+
+	return ethMsg, nil
+}
+
+// UnpackInterfaces implements UnpackInterfacesMesssage.UnpackInterfaces
+func (msg MsgEthereumTx) UnpackInterfaces(unpacker codectypes.AnyUnpacker) error {
+	return unpacker.UnpackAny(msg.Data, new(TxData))
+}
+
+// BuildTx builds the canonical cosmos tx from ethereum msg
+func (msg *MsgEthereumTx) BuildTx(b client.TxBuilder, evmDenom string) (authsigning.Tx, error) {
+	builder, ok := b.(authtx.ExtensionOptionsTxBuilder)
+	if !ok {
+		return nil, errors.New("unsupported builder")
+	}
+
+	option, err := codectypes.NewAnyWithValue(&ExtensionOptionsEthereumTx{})
+	if err != nil {
+		return nil, err
+	}
+
+	txData, err := UnpackTxData(msg.Data)
+	if err != nil {
+		return nil, err
+	}
+	fees := make(sdk.Coins, 0)
+	feeAmt := sdkmath.NewIntFromBigInt(txData.Fee())
+	if feeAmt.Sign() > 0 {
+		fees = append(fees, sdk.NewCoin(evmDenom, feeAmt))
+	}
+
+	builder.SetExtensionOptions(option)
+
+	err = builder.SetMsgs(msg)
+	if err != nil {
+		return nil, err
+	}
+	builder.SetFeeAmount(fees)
+	builder.SetGasLimit(msg.GetGas())
+	tx := builder.GetTx()
+	return tx, nil
+}

--- a/legacy/evm/types.go
+++ b/legacy/evm/types.go
@@ -44,6 +44,30 @@ type TxData interface {
 	EffectiveCost(baseFee *big.Int) *big.Int
 }
 
+// NewAccessList creates a new protobuf-compatible AccessList from an ethereum
+// core AccessList type
+func NewAccessList(ethAccessList *ethtypes.AccessList) AccessList {
+	if ethAccessList == nil {
+		return nil
+	}
+
+	al := AccessList{}
+	for _, tuple := range *ethAccessList {
+		storageKeys := make([]string, len(tuple.StorageKeys))
+
+		for i := range tuple.StorageKeys {
+			storageKeys[i] = tuple.StorageKeys[i].String()
+		}
+
+		al = append(al, AccessTuple{
+			Address:     tuple.Address.String(),
+			StorageKeys: storageKeys,
+		})
+	}
+
+	return al
+}
+
 func (al AccessList) ToEthAccessList() *ethtypes.AccessList {
 	var ethAccessList ethtypes.AccessList
 


### PR DESCRIPTION
Some of these are needed in rpcs to decode legacy MsgEthereumTxs. Copied only needed funcs from ethermint code.