### PR TITLE
fix: extract numeric chain ID before trying parse in UINT for eip712 trasnactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### BUG FIXES
 
 - [\#748](https://github.com/cosmos/evm/pull/748) Fix DynamicFeeChecker in Cosmos ante handler to respect NoBaseFee feemarkets' parameter.
+- [#19](https://github.com/zeta-chain/evm/pull/19) - Extract numeric chain ID before trying parse to UINT for eip712 transactions
 
 ## v0.5.0
 

--- a/ante/cosmos/eip712.go
+++ b/ante/cosmos/eip712.go
@@ -3,6 +3,7 @@ package cosmos
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
@@ -31,6 +32,38 @@ func init() {
 	registry := codectypes.NewInterfaceRegistry()
 	eip712.RegisterInterfaces(registry)
 	evmCodec = codec.NewProtoCodec(registry)
+}
+
+// parseChainID parses a chain ID string and returns the EVM chain ID as uint64.
+// Examples:
+//   - "7000" -> 7000
+//   - "zetachain_7000-1" -> 7000
+//   - "cosmoshub_400-1" -> 400
+func parseChainID(chainID string) (uint64, error) {
+	// First, try to parse as a pure numeric chain ID
+	if evmChainID, err := strconv.ParseUint(chainID, 10, 64); err == nil {
+		return evmChainID, nil
+	}
+
+	// Try to extract EVM chain ID from Cosmos SDK format: {chain_name}_{evm_chain_id}-{revision}
+	// Find the position of the underscore and dash
+	underscoreIdx := strings.Index(chainID, "_")
+	dashIdx := strings.Index(chainID, "-")
+
+	// Check if both characters are found and in the correct order
+	if underscoreIdx == -1 || dashIdx == -1 || underscoreIdx > dashIdx {
+		return 0, fmt.Errorf("invalid chain-id format: %s (expected numeric or {chain_name}_{evm_chain_id}-{revision})", chainID)
+	}
+
+	// Extract the substring between underscore and dash
+	evmChainIDStr := chainID[underscoreIdx+1 : dashIdx]
+
+	evmChainID, err := strconv.ParseUint(evmChainIDStr, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse EVM chain-id from %s: %w", chainID, err)
+	}
+
+	return evmChainID, nil
 }
 
 // Deprecated: LegacyEip712SigVerificationDecorator Verify all signatures for a tx and return an error if any are invalid. Note,
@@ -189,7 +222,7 @@ func VerifySignature(
 			msgs, tx.GetMemo(),
 		)
 
-		signerChainID, err := strconv.ParseUint(signerData.ChainID, 10, 64)
+		signerChainID, err := parseChainID(signerData.ChainID)
 		if err != nil {
 			return errorsmod.Wrapf(err, "failed to parse chain-id: %s", signerData.ChainID)
 		}

--- a/ante/cosmos/eip712_test.go
+++ b/ante/cosmos/eip712_test.go
@@ -1,0 +1,102 @@
+package cosmos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseChainID(t *testing.T) {
+	testCases := []struct {
+		name        string
+		chainID     string
+		expected    uint64
+		expectError bool
+	}{
+		{
+			name:        "pure numeric chain ID",
+			chainID:     "7000",
+			expected:    7000,
+			expectError: false,
+		},
+		{
+			name:        "zetachain mainnet format",
+			chainID:     "zetachain_7000-1",
+			expected:    7000,
+			expectError: false,
+		},
+		{
+			name:        "zetachain testnet format",
+			chainID:     "zetachain_7001-1",
+			expected:    7001,
+			expectError: false,
+		},
+		{
+			name:        "chain with higher revision",
+			chainID:     "mychain_12345-99",
+			expected:    12345,
+			expectError: false,
+		},
+		{
+			name:        "chain ID with underscore in name - not supported",
+			chainID:     "my_chain_100-1",
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "missing underscore",
+			chainID:     "zetachain7000-1",
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "missing dash",
+			chainID:     "zetachain_7000",
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "underscore after dash",
+			chainID:     "zetachain-7000_1",
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "non-numeric EVM chain ID",
+			chainID:     "zetachain_abc-1",
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "empty string",
+			chainID:     "",
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "only underscore and dash",
+			chainID:     "_-",
+			expected:    0,
+			expectError: true,
+		},
+		{
+			name:        "large numeric chain ID",
+			chainID:     "18446744073709551615",
+			expected:    18446744073709551615,
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := parseChainID(tc.chainID)
+
+			if tc.expectError {
+				require.Error(t, err, "expected error for chain ID: %s", tc.chainID)
+			} else {
+				require.NoError(t, err, "unexpected error for chain ID: %s", tc.chainID)
+				require.Equal(t, tc.expected, result, "unexpected result for chain ID: %s", tc.chainID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description



<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes:(https://github.com/zeta-chain/node/issues/4222)

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
